### PR TITLE
Fix division by zero error in rosbag playback

### DIFF
--- a/src/diff_drive/odometry.py
+++ b/src/diff_drive/odometry.py
@@ -67,9 +67,9 @@ class Odometry:
         self.pose.x += deltaX
         self.pose.y += deltaY
         self.pose.theta = (self.pose.theta + deltaTheta) % (2*pi)
-        self.pose.xVel = deltaTravel / deltaTime
+        self.pose.xVel = deltaTravel / deltaTime if deltaTime > 0 else 0.
         self.pose.yVel = 0
-        self.pose.thetaVel = deltaTheta / deltaTime
+        self.pose.thetaVel = deltaTheta / deltaTime if deltaTime > 0 else 0.
 
         self.lastTime = newTime
 


### PR DESCRIPTION
[INFO] [1510936022.126839, 0.000000]: /diff_drive_odometry started169086                                 
Traceback (most recent call last):08541   Duration: 0.000000 / 13.169086                                 
  File "//catkin_ws/src/diff_drive/nodes/diff_drive_odometry", line 89, in <module>             
    node.main()                                                                                          
  File "//catkin_ws/src/diff_drive/nodes/diff_drive_odometry", line 45, in main                 
    self.publish()                                                                                       
  File "//catkin_ws/src/diff_drive/nodes/diff_drive_odometry", line 49, in publish              
    self.odometry.updatePose(rospy.get_time())                                                           
  File "//catkin_ws/src/diff_drive/src/diff_drive/odometry.py", line 70, in updatePose          
    self.pose.xVel = deltaTravel / deltaTime                                                             
ZeroDivisionError: float division by zero